### PR TITLE
Add Processor.{as_ids,as_pieces}

### DIFF
--- a/cysp/sp.pxd
+++ b/cysp/sp.pxd
@@ -5,7 +5,7 @@ from libcpp.string cimport string
 cdef extern from "builtin_pb/sentencepiece.pb.h" namespace "sentencepiece":
     cdef cppclass SentencePieceText_SentencePiece:
         uint32_t id() const
-        const string &piece() const
+        const string & piece() const
 
     cdef cppclass SentencePieceText:
         const SentencePieceText_SentencePiece& pieces(int index) const;
@@ -16,7 +16,7 @@ cdef extern from "sentencepiece_processor.h" namespace "sentencepiece":
     cdef cppclass SentencePieceProcessor:
         SentencePieceProcessor()
         string EncodeAsSerializedProto(const string& filename)
-        Status Encode(const string& input, SentencePieceText* spt)
+        Status Encode(const string& input, SentencePieceText * spt)
         Status Load(string filename)
 
 cdef extern from "sentencepiece_processor.h" namespace "sentencepiece::util":
@@ -26,7 +26,7 @@ cdef extern from "sentencepiece_processor.h" namespace "sentencepiece::util":
 
     cdef cppclass Status:
         StatusCode code() const
-        const char* error_message() const
+        const char * error_message() const
 
 cdef extern from "sentencepiece_processor.h" namespace "sentencepiece::util::StatusCode":
     cdef StatusCode kOk
@@ -35,3 +35,5 @@ cdef extern from "sentencepiece_processor.h" namespace "sentencepiece::util::Sta
 
 cdef class Processor:
     cdef shared_ptr[SentencePieceProcessor] spp
+
+    cdef SentencePieceText _encode(self, str sentence)

--- a/cysp/test/test_sp.py
+++ b/cysp/test/test_sp.py
@@ -26,11 +26,37 @@ def test_handles_nul_character(toy_model):
     assert pieces == ["▁T", "est", "\0", "▁", "n", "ul"]
 
 
-def test_toy_model(toy_model):
+def test_encode(toy_model):
     ids, pieces = toy_model.encode("I saw a girl with a telescope.")
     numpy.testing.assert_equal(
         ids, [8, 465, 10, 947, 41, 10, 170, 168, 110, 28, 20, 143, 4]
     )
+    assert pieces == [
+        "▁I",
+        "▁saw",
+        "▁a",
+        "▁girl",
+        "▁with",
+        "▁a",
+        "▁t",
+        "el",
+        "es",
+        "c",
+        "o",
+        "pe",
+        ".",
+    ]
+
+
+def test_encode_as_ids(toy_model):
+    ids = toy_model.encode_as_ids("I saw a girl with a telescope.")
+    numpy.testing.assert_equal(
+        ids, [8, 465, 10, 947, 41, 10, 170, 168, 110, 28, 20, 143, 4]
+    )
+
+
+def test_encode_as_pieces(toy_model):
+    pieces = toy_model.encode_as_pieces("I saw a girl with a telescope.")
     assert pieces == [
         "▁I",
         "▁saw",


### PR DESCRIPTION
These methods can be used when only one of the representations is needed 
and you don't want to pay the overhead for constructing the other.
