### PR TITLE
Fix segmentation fault when using *_id with uninitialized processor

### DIFF
--- a/cysp/sp.pxd
+++ b/cysp/sp.pxd
@@ -22,6 +22,7 @@ cdef extern from "sentencepiece_processor.h" namespace "sentencepiece":
         Status Encode(const string& input, SentencePieceText * spt)
         Status Load(const string& filename)
         Status LoadFromSerializedProto(string_view serialized);
+        Status status() const
         int bos_id() const
         int eos_id() const
         int pad_id() const

--- a/cysp/sp.pyx
+++ b/cysp/sp.pyx
@@ -81,15 +81,19 @@ cdef class SentencePieceProcessor:
         return pieces
 
     def bos_id(self):
+        _check_status(deref(self.spp).status())
         return deref(self.spp).bos_id()
 
     def eos_id(self):
+        _check_status(deref(self.spp).status())
         return deref(self.spp).eos_id()
 
     def pad_id(self):
+        _check_status(deref(self.spp).status())
         return deref(self.spp).pad_id()
 
     def unk_id(self):
+        _check_status(deref(self.spp).status())
         return deref(self.spp).unk_id()
 
     cdef SentencePieceText _encode(self, str sentence) except *:

--- a/cysp/test/test_sp.py
+++ b/cysp/test/test_sp.py
@@ -124,6 +124,14 @@ def test_uninitialized_model():
         spp.decode_from_pieces(["▁I"])
     with pytest.raises(RuntimeError):
         spp.decode_from_ids([8])
+    with pytest.raises(RuntimeError):
+        spp.bos_id()
+    with pytest.raises(RuntimeError):
+        spp.eos_id()
+    with pytest.raises(RuntimeError):
+        spp.unk_id()
+    with pytest.raises(RuntimeError):
+        spp.pad_id()
 
 
 def _check_ids(spp):


### PR DESCRIPTION
The sentencepiece library does not check if a model is loaded when using
(bos|eos|pad|unk)_id. This leads to a segmentation fault when using one of
these methods on an uninitialized model. Do these checks ourselves to ensure
that we raise an exception instead.
